### PR TITLE
Fixed docs issues for katacoda

### DIFF
--- a/install-on-kubernetes/assets/common-deploy-on-k8s.sh
+++ b/install-on-kubernetes/assets/common-deploy-on-k8s.sh
@@ -17,10 +17,11 @@ echo "* helm: OK"
 echo
 echo "Deploying Aporeto..."
 kubectl create namespace aporeto
+kubectl create namespace aporeto-operator
 
 apoctl appcred create aporeto-operator \
   --role @auth:role=aporeto-operator \
-  --type k8s | kubectl apply -f - -n aporeto > /dev/null || exit 1
+  --type k8s | kubectl apply -f - -n aporeto-operator > /dev/null || exit 1
 echo "* aporeto-operator appcreds: OK"
 
 apoctl appcred create enforcerd \
@@ -34,7 +35,7 @@ helm install \
 
 helm install \
     --name aporeto-operator \
-    --namespace aporeto \
+    --namespace aporeto-operator \
     aporeto/aporeto-operator > /dev/null || exit 1
 echo "* aporeto-operator deployed: OK"
 

--- a/install-on-kubernetes/step2.md
+++ b/install-on-kubernetes/step2.md
@@ -2,15 +2,16 @@ App Credentials (appcreds) are JSON files that contain a negociated
 x509 certificate used for authentication
 as well as more information about the control plane.
 
-> Learn more about [App Credentials](https://junon.console.aporeto.com/docs/main/references/appcredentials/).
+> Learn more about [App Credentials](https://docs.aporeto.com/saas/reference/resources/app-cred/).
 
 We need to create an one appcred for
-[enforcerd](https://junon.console.aporeto.com/docs/main/concepts/enforcerd-and-processing-units/)
-and one for [aporeto-operator](https://junon.console.aporeto.com/docs/main/installation/install-on-kubernetes/).
+[enforcerd](https://docs.aporeto.com/saas/concepts/#enforcer)
+and one for [aporeto-operator](https://docs.aporeto.com/saas/start/enforcer/k8s/).
 As we are going to deploy both enforcerd and aporeto-operator in the Kubernetes namespaces `aporeto` and `aporeto-operator`, we must first create these namespaces:
 
 ```
-kubectl create namespace aporeto aporeto-operator
+kubectl create namespace aporeto
+kubectl create namespace aporeto-operator
 ```{{execute}}
 
 Then create the appcreds for aporeto-operator:
@@ -22,7 +23,7 @@ apoctl appcred create aporeto-operator \
 ```{{execute}}
 
 This creates the appcred named `aporeto-operator` in the
-current apoctl namespace with the role `aporeto-operator` and
+aporeto-operator namespace with the role `aporeto-operator` and
 prints the output as a
 [Kubernetes Secret Definition](https://kubernetes.io/docs/concepts/configuration/secret/).
 The output is then piped to `kubectl` to apply it in the Kubernetes namespace `aporeto-operator`.


### PR DESCRIPTION
1. Linked correct docs links which were leading to 404 not found 2. aporeto operator should be insatlled in aporeto-operator namespace, fixed it in all the left-over files too 3. Minor documentation change